### PR TITLE
Fix gulpfile, so that it doesn't require HTTP auth.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ gulp.task('deploy', ['cname', 'html', 'sass', 'assets'], () => {
   const DEPLOY_OPTS = { remoteUrl: "git@github.com/allenai/oasp-website" };
 
   return gulp.src(`${BUILD_DIR}/**/*`)
-    .pipe(deployToGithubPages());
+    .pipe(deployToGithubPages(DEPLOY_OPTS));
 });
 
 gulp.task('dev', () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,10 +37,10 @@ gulp.task('cname', () => {
 });
 
 gulp.task('deploy', ['cname', 'html', 'sass', 'assets'], () => {
-  const DEPLOY_OPTS = { remoteUrl: "https://github.com/allenai/oasp-website.git" };
+  const DEPLOY_OPTS = { remoteUrl: "git@github.com/allenai/oasp-website" };
 
   return gulp.src(`${BUILD_DIR}/**/*`)
-    .pipe(deployToGithubPages(DEPLOY_OPTS));
+    .pipe(deployToGithubPages());
 });
 
 gulp.task('dev', () => {


### PR DESCRIPTION
@bbstilson This nearly screwed me up this morning.  Using `https` doesn't work for some of us who use SSH based authentication.

If this doesn't work for you, LMK. We can get you setup via SSH, I think it's ideal for several reasons.