### PR TITLE
Upgrade 'extend' to v3.0.2 to fix security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1298,9 +1298,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {
@@ -3412,7 +3412,7 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
+        "extend": "3.0.2",
         "findup-sync": "2.0.0",
         "fined": "1.1.0",
         "flagged-respawn": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "private": true,
   "devDependencies": {
     "browser-sync": "2.26.3",
+    "extend": "3.0.2",
     "gulp": "3.9.1"
   },
   "dependencies": {


### PR DESCRIPTION
This is a fix for the security issue for the `extend` library, and addresses Sev 3, https://github.com/allenai/scholar/issues/13690.

Link to alert:
https://github.com/allenai/oasp-website/network/alert/package-lock.json/extend/open